### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## What is Bloomer?
 
 Bloomer is a utility library to help website authors guide their
-users into picking better passwords. It generates a [Bloom Filter](http://en.wikipedia.org/wiki/Bloom_filter) of comprimised passwords,
+users into picking better passwords. It generates a [Bloom Filter](http://en.wikipedia.org/wiki/Bloom_filter) of compromised passwords,
 which are obtained from public security lists on the Internet.
 
 The password lists used by Bloomer do not contain identifiable user information, such as


### PR DESCRIPTION
@krisives, I've corrected a typographical error in the documentation of the [bloomer-php](https://github.com/krisives/bloomer-php) project. Specifically, I've changed comprimise to compromise. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
